### PR TITLE
chore: bump Anki version to 26.08.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Docker Compose 变量插值（本文件仅含版本号，安全可提交）
 # 版本唯一源：check-upstream 自动检查、CI 构建、本地 compose 构建均从此处读取
-ANKI_VERSION=26.08
+ANKI_VERSION=26.08.1


### PR DESCRIPTION
自动检测到 Anki 上游有新版本发布。

- 当前版本: 26.08
- 最新版本: 26.08.1

合并后将自动触发多架构镜像构建。

---
*此 PR 由调试工具手动创建，因 GitHub Actions 默认 GITHUB_TOKEN 当前未获授权创建 PR（见下方说明）。*